### PR TITLE
Fixed Limit Suggestions

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -49,7 +49,7 @@ class Tags extends Field
 
     public function limitSuggestions(int $maxNumberOfSuggestions)
     {
-        return $this->withMeta(['suggestionLimit', $maxNumberOfSuggestions]);
+        return $this->withMeta(['suggestionLimit' => $maxNumberOfSuggestions]);
     }
 
     public function doNotLimitSuggestions()


### PR DESCRIPTION
withoutSuggestions() and limitSuggestions() did not work in latest Nova release, possibly due to change in v2.8.0. 

This fixes it for me - hope this helps!